### PR TITLE
Add mac toolchain and Update targets for mac build.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -5,3 +5,12 @@ platforms:
     - "..."
     test_targets:
     - "..."
+  macos:
+    build_targets:
+    - "..."
+    - "-//examples/cpan:IOTty"
+    - "-//examples/cpan:IOTtyXS"
+    - "-//examples/external_module:complex_deps"
+    test_targets:
+    - "..."
+    - "-//examples/external_module:complex_deps"

--- a/perl/deps.bzl
+++ b/perl/deps.bzl
@@ -15,7 +15,19 @@ def perl_register_toolchains():
         ]
     )
 
+    perl_download(
+        name = "perl_darwin_amd64",
+        arch = "amd64",
+        os = "darwin",
+        strip_prefix = "perl-darwin-2level",
+        sha256 = "9ede6e5200d2b69524ed8074edbcddf8c4c3e8f67a756edce133cabaa4ad2347",
+        urls = [
+            "https://github.com/skaji/relocatable-perl/releases/download/5.30.1.1/perl-darwin-2level.tar.xz",
+        ]
+    )
+
     native.register_toolchains(
+        "@perl_darwin_amd64//:toolchain",
         "@perl_linux_amd64//:toolchain",
     )
 


### PR DESCRIPTION
This should provide all functionality that rules_perl currently provides
for Mac.

Hopefully, the perl_xs rule will be updated to be more platform
independent soon.